### PR TITLE
Add exercises that have arguments.

### DIFF
--- a/prototypes/datasets/boardGames.js
+++ b/prototypes/datasets/boardGames.js
@@ -1,0 +1,28 @@
+const boardGames = {
+  strategy: [
+    { name: 'Chess', rating: 6.9, maxPlayers: 2 },
+    { name: 'Catan', rating: 6.9, maxPlayers: 6 },
+    { name: 'Checkers', rating: 5.9, maxPlayers: 2 },
+    { name: 'Pandemic', rating: 7.4, maxPlayers: 4 },
+    { name: 'Battle Ship', rating: 5.7, maxPlayers: 2 },
+    { name: 'Azul', rating: 8.8, maxPlayers: 4 },
+    { name: 'Ticket To Ride', rating: 7.4, maxPlayers: 4 },
+  ],
+  party: [
+    { name: 'Werewolf', rating: 6.1, maxPlayers: 24 },
+    { name: 'Cards Against Humanity', rating: 5.6, maxPlayers: 30 },
+    { name: 'Codenames', rating: 7.4, maxPlayers: 8 }, 
+    { name: 'Sushi Go! Party', rating: 6.9, maxPlayers: 8 },
+    { name: 'Tsuro', rating: 6.7, maxPlayers: 8 },
+  ],
+  childrens: [
+    { name: 'Candy Land', rating: 3.8, maxPlayers: 4 },
+    { name: 'Connect Four', rating: 4.9, maxPlayers: 2 },
+    { name: 'Operation', rating: 4.5, maxPlayers: 6 },
+    { name: 'Trouble', rating: 3.8, maxPlayers: 4 },
+  ],
+}
+
+module.exports = {
+  boardGames,
+}

--- a/prototypes/index.js
+++ b/prototypes/index.js
@@ -496,6 +496,18 @@ const breweryPrompts = {
     // Write your annotation here as a comment
   },
 
+  getSingleBreweryBeerCount(breweryName) {
+    // Return a number that is the count of beers that the specified
+    // brewery has e.g.
+    // given 'Ratio Beerworks', return 5
+
+
+    /* CODE GOES HERE */
+
+    // Annotation:
+    // Write your annotation here as a comment
+  },
+
   findHighestAbvBeer() {
     // Return the beer which has the highest ABV of all beers
     // e.g.

--- a/prototypes/index.js
+++ b/prototypes/index.js
@@ -6,11 +6,13 @@ const { classrooms } = require('./datasets/classrooms');
 const { breweries } = require('./datasets/breweries');
 const { nationalParks } = require('./datasets/nationalParks');
 const { weather } = require('./datasets/weather');
+const { boardGames } = require('./datasets/boardGames');
 const { instructors, cohorts } = require('./datasets/turing');
 const { bosses, sidekicks } = require('./datasets/bosses');
 const { constellations, stars } = require('./datasets/astronomy');
 const { weapons, characters } = require('./datasets/ultima');
 const { dinosaurs, humans, movies } = require('./datasets/dinosaurs');
+
 
 
 // SINGLE DATASETS
@@ -491,6 +493,74 @@ const breweryPrompts = {
 };
 
 
+// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+
+// DATASET: weather from './datasets/boardGames
+
+const boardGamePrompts = {
+  listGames(type) {
+    // Return an array of just the names of the games within a specified type. 
+    // e.g. given an argument of "strategy", return
+    // ["Chess", "Catan", "Checkers", "Pandemic", "Battle Ship", "Azul", "Ticket to Ride"]
+
+    /* CODE GOES HERE */
+
+    // Annotation:
+    // Write your annotation here as a comment
+  },
+
+  listGamesAlphabetically(type) {
+    // Return an array of just the names of the games within a specified 
+    // type, sorted alphabetically. 
+    // e.g. given an argument of "childrens", return
+    // ["Candy Land", "Connect Four", "Operation", "Trouble"]
+
+    /* CODE GOES HERE */
+
+    // Annotation:
+    // Write your annotation here as a comment
+  },
+
+  findHighestRatedGamesByType(type) {
+    // Return an object which is the highest rated game within the specified type.
+    // e.g. given the argument of 'party', return
+    // { name: 'Codenames', rating: 7.4, maxPlayers: 8 },
+
+    /* CODE GOES HERE */
+
+    // Annotation:
+    // Write your annotation here as a comment
+  },
+
+  averageScoreByType(type) {
+    // Return the average score for the specified type.
+    // e.g. given the argument of "strategy", return 7
+    // note: do not worry about rounding your result.
+
+    /* CODE GOES HERE */
+
+    // Annotation:
+    // Write your annotation here as a comment
+  },
+
+  averageScoreByTypeAndPlayers(type, maximumPlayers) {
+    // Return the average score of any games that match the specified type
+    // and maximum number of players.
+    // e.g. given the arguments of "strategy" and 2, return 6.16666666667
+    // note: do not worry about rounding your result.
+
+    /* CODE GOES HERE */
+
+    // Annotation:
+    // Write your annotation here as a comment
+  }
+};
+
+
 
 
 
@@ -892,5 +962,6 @@ module.exports = {
   nationalParksPrompts,
   weatherPrompts,
   bookPrompts,
-  dinosaurPrompts
+  dinosaurPrompts,
+  boardGamePrompts,
 };

--- a/prototypes/index.js
+++ b/prototypes/index.js
@@ -311,6 +311,20 @@ const bookPrompts = {
     // Write your annotation here as a comment
 
   },
+  getNewBooks() {
+    // return an array of objects containing all books that were
+    // published in the 90's and 00's. Inlucde the title and the year Eg:
+
+    // [{ title: 'Harry Potter and the Sorcerer\'s Stone', year: 1997 },
+    //  { title: 'Life of Pi', year: 2001 },
+    //  { title: 'The Curious Incident of the Dog in the Night-Time', year: 2003 }]
+
+    /* CODE GOES HERE */
+
+    // Annotation:
+    // Write your annotation here as a comment
+  },
+
   getBooksByYear(books, year) {
     // return an array of objects containing all books that were
     // published after the specified year without the author or genre data. 

--- a/prototypes/index.js
+++ b/prototypes/index.js
@@ -311,9 +311,11 @@ const bookPrompts = {
     // Write your annotation here as a comment
 
   },
-  getNewBooks() {
+  getBooksByYear(books, year) {
     // return an array of objects containing all books that were
-    // published in the 90's and 00's. Inlucde the title and the year Eg:
+    // published after the specified year without the author or genre data. 
+    // The published property should be changed to year for the returned books.
+    // e.g. given 1990, return
 
     // [{ title: 'Harry Potter and the Sorcerer\'s Stone', year: 1997 },
     //  { title: 'Life of Pi', year: 2001 },

--- a/test/prototype-test.js
+++ b/test/prototype-test.js
@@ -20,6 +20,7 @@ const {
   nationalParksPrompts,
   weatherPrompts,
   bookPrompts,
+  boardGamePrompts,
 } = require("../prototypes/index");
 
 describe("PROTOTYPES", () => {
@@ -459,6 +460,58 @@ describe("PROTOTYPES", () => {
       })
     })
   });
+
+  describe("Board Game Prompts", () => {
+    it.skip("listGames", () => {
+      const strategyGames = boardGamePrompts.listGames('strategy');
+      const childrensGames = boardGamePrompts.listGames('childrens');
+      const partyGames = boardGamePrompts.listGames('party');
+
+      expect(strategyGames).to.deep.equal(["Chess", "Catan", "Checkers", "Pandemic", "Battle Ship", "Azul", "Ticket To Ride"]);
+      expect(childrensGames).to.deep.equal(["Candy Land", "Connect Four", "Operation", "Trouble"]);
+      expect(partyGames).to.deep.equal(["Werewolf", "Cards Against Humanity", "Codenames", "Sushi Go! Party", "Tsuro"]);
+    });
+
+    it.skip("listGamesAlphabetically", () => {
+      const strategyGames = boardGamePrompts.listGamesAlphabetically('strategy');
+      const childrensGames = boardGamePrompts.listGamesAlphabetically('childrens');
+      const partyGames = boardGamePrompts.listGamesAlphabetically('party');
+
+      expect(strategyGames).to.deep.equal(["Azul", "Battle Ship", "Catan", "Checkers", "Chess", "Pandemic", "Ticket To Ride"]);
+      expect(childrensGames).to.deep.equal(["Candy Land", "Connect Four", "Operation", "Trouble"]);
+      expect(partyGames).to.deep.equal(["Cards Against Humanity", "Codenames", "Sushi Go! Party", "Tsuro", "Werewolf"]);
+    });
+
+    it.skip("findHighestRatedGamesByType", () => {
+      const highestStrategy = boardGamePrompts.findHighestRatedGamesByType('strategy');
+      const highestChildrens = boardGamePrompts.findHighestRatedGamesByType('childrens');
+      const highestParty = boardGamePrompts.findHighestRatedGamesByType('party');
+
+      expect(highestStrategy).to.deep.equal({ name: 'Azul', rating: 8.8, maxPlayers: 4 });
+      expect(highestChildrens).to.deep.equal({ name: 'Connect Four', rating: 4.9, maxPlayers: 2 });
+      expect(highestParty).to.deep.equal({ name: 'Codenames', rating: 7.4, maxPlayers: 8 });
+    });
+
+    it.skip("averageScoreByType", () => {
+      const avScoreStrat = boardGamePrompts.averageScoreByType('strategy');
+      const avScoreChildren = boardGamePrompts.averageScoreByType('childrens');
+      const avScoreParty = boardGamePrompts.averageScoreByType('party');
+      
+      expect(Math.round(avScoreStrat * 100) / 100).to.equal(7);
+      expect(Math.round(avScoreChildren * 100) / 100).to.equal(4.25);
+      expect(Math.round(avScoreParty * 100) / 100).to.equal(6.54);
+    });
+
+    it.skip("averageScoreByTypeAndPlayers", () => {
+      const avScoreStrat = boardGamePrompts.averageScoreByTypeAndPlayers('strategy', 2);
+      const avScoreChildren = boardGamePrompts.averageScoreByTypeAndPlayers('childrens', 4);
+      const avScoreParty = boardGamePrompts.averageScoreByTypeAndPlayers('party', 8);
+      Math.round(avScoreChildren * 100) / 100
+      expect(Math.round(avScoreStrat * 100) / 100).to.equal(6.17); // 2 players
+      expect(Math.round(avScoreChildren * 100) / 100).to.equal(3.8); // 4 players
+      expect(Math.round(avScoreParty * 100) / 100).to.equal(7); // 8 players
+    });
+  })
 
   describe("Turing Prompts", () => {
     it.skip("studentsForEachInstructor", () => {

--- a/test/prototype-test.js
+++ b/test/prototype-test.js
@@ -340,8 +340,8 @@ describe("PROTOTYPES", () => {
         'Treasure Island'])
     });
 
-    it.skip("getNewBooks", () => {
-      const e = bookPrompts.getNewBooks(books);
+    it("getBooksByYear", () => {
+      const e = bookPrompts.getBooksByYear(books, 1990);
 
       expect(e).to.deep.equal([{
         title: 'Harry Potter and the Sorcerer\'s Stone', year: 1997
@@ -350,7 +350,17 @@ describe("PROTOTYPES", () => {
       {
         title: 'The Curious Incident of the Dog in the Night-Time', year: 2003
       }])
-    })
+    }); 
+
+      const earlyBooks = bookPrompts.getBooksByYear(books, 1970);
+      expect(earlyBooks).to.deep.equal([
+        { title: "Harry Potter and the Sorcerer's Stone", year: 1997 },
+        { title: "The Hitchhiker's Guide to the Galaxy", year: 1979 },
+        { title: "The Handmaid's Tale", year: 1985 },
+        { title: 'Life of Pi', year: 2001 },
+        { title: 'The Curious Incident of the Dog in the Night-Time', year: 2003 },
+        { title: 'Interview with the Vampire', year: 1976 }
+      ]);
   });
 
   describe("Weather prompts", () => {

--- a/test/prototype-test.js
+++ b/test/prototype-test.js
@@ -471,6 +471,14 @@ describe("PROTOTYPES", () => {
       }])
     });
 
+    it.skip("getSingleBreweryBeerCount", () => {
+      const ratioCount = breweryPrompts.getSingleBreweryBeerCount('Ratio Beerworks');
+      const plattCount = breweryPrompts.getSingleBreweryBeerCount('Platt Park Brewing Co.');
+
+      expect(ratioCount).to.equal(5);
+      expect(plattCount).to.equal(7);
+    });
+
     it.skip("findHighestAbvBeer", () => {
       const e = breweryPrompts.findHighestAbvBeer();
 

--- a/test/prototype-test.js
+++ b/test/prototype-test.js
@@ -340,7 +340,19 @@ describe("PROTOTYPES", () => {
         'Treasure Island'])
     });
 
-    it("getBooksByYear", () => {
+    it.skip("getNewBooks", () => {
+      const e = bookPrompts.getNewBooks(books);
+
+      expect(e).to.deep.equal([{
+        title: 'Harry Potter and the Sorcerer\'s Stone', year: 1997
+      },
+      { title: 'Life of Pi', year: 2001 },
+      {
+        title: 'The Curious Incident of the Dog in the Night-Time', year: 2003
+      }])
+    });
+
+    it.skip("getBooksByYear", () => {
       const e = bookPrompts.getBooksByYear(books, 1990);
 
       expect(e).to.deep.equal([{
@@ -350,7 +362,6 @@ describe("PROTOTYPES", () => {
       {
         title: 'The Curious Incident of the Dog in the Night-Time', year: 2003
       }])
-    }); 
 
       const earlyBooks = bookPrompts.getBooksByYear(books, 1970);
       expect(earlyBooks).to.deep.equal([
@@ -361,6 +372,7 @@ describe("PROTOTYPES", () => {
         { title: 'The Curious Incident of the Dog in the Night-Time', year: 2003 },
         { title: 'Interview with the Vampire', year: 1976 }
       ]);
+    }); 
   });
 
   describe("Weather prompts", () => {


### PR DESCRIPTION
**What**: 
- add new test set and add a couple of individual tests to existing sets. 

**Why**: 
- There were no opportunities for students to practice exercises that are similar to what we expect of them in assessments. Of course, it would be nice if students automatically understood how two concepts come together (arguments and iterators), but it seems unfair to not offer at least a few. I meant to do this months ago, but have been having a rough time and couldn't swing it. Better late than never! See[ this thread ](https://turingschool.slack.com/archives/C02E680NHA5/p1646325204217999)for more info.

**Notes**:
-  I'm really horrible at naming things - please let me know if there are any awful names that could be updated. 
- I have it blocks with multiple expect statements. I am doing this to offer a more rounded test so that students have less opportunity to accidentally hard code something while learning but I didn't break these into separate it blocks in order to follow the pattern that the other tests utilize. I wasn't sure which was the bigger sin, breaking the it blocks up in a pattern that differs from the pattern in place in the file or having multiple expects within a block. I went with the latter, since that's how we always did tests in the wild anyways. 🤷‍♀️ 
- I only added new functions or sets instead of updating old ones in hopes that it will lessen the amount of merge conflicts students my get when pulling this down. I figured with only new items, there probably wouldn't be any issue 🤞 .
- I am afraid to lint this whole thing in fear of my linter doing something weird and also causing issues for any students currently using this. (I really wish I would have remembered to do this over intermission...) So, linting of my new stuff may be spotty. Please be picky! I definitely don't mean for it to be messy but I've used format commands as a crutch for too long 😂 